### PR TITLE
Update Grunt packages

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,7 @@ module.exports = function(grunt) {
       },
       sass: {
         files: 'scss/*.scss',
-        tasks: ['sass', 'autoprefixer', 'bsReload:css']
+        tasks: ['sass', 'postcss', 'bsReload:css']
       },
       html: {
         files: '*.html',
@@ -28,9 +28,11 @@ module.exports = function(grunt) {
       }
     },
 
-    autoprefixer: {
+    postcss: {
       options: {
-        browsers: ['last 2 versions', 'ie 8', 'ie 9']
+        processors: [
+          require('autoprefixer')({browsers: ['last 2 versions', 'ie 8', 'ie 9']})
+        ]
       },
       dist: {
         files: {
@@ -60,7 +62,7 @@ module.exports = function(grunt) {
 
   // Load dependencies
   grunt.loadNpmTasks('grunt-browser-sync');
-  grunt.loadNpmTasks('grunt-autoprefixer');
+  grunt.loadNpmTasks('grunt-postcss');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-sass');
 

--- a/css/cayman.css
+++ b/css/cayman.css
@@ -111,7 +111,12 @@ a {
       font-size: 1rem; } }
   .main-content img {
     max-width: 100%; }
-  .main-content h1, .main-content h2, .main-content h3, .main-content h4, .main-content h5, .main-content h6 {
+  .main-content h1,
+  .main-content h2,
+  .main-content h3,
+  .main-content h4,
+  .main-content h5,
+  .main-content h6 {
     margin-top: 2rem;
     margin-bottom: 1rem;
     font-weight: normal;
@@ -149,14 +154,16 @@ a {
     .main-content .highlight pre {
       margin-bottom: 0;
       word-break: normal; }
-  .main-content .highlight pre, .main-content pre {
+  .main-content .highlight pre,
+  .main-content pre {
     padding: 0.8rem;
     overflow: auto;
     font-size: 0.9rem;
     line-height: 1.45;
     border-radius: 0.3rem;
     -webkit-overflow-scrolling: touch; }
-  .main-content pre code, .main-content pre tt {
+  .main-content pre code,
+  .main-content pre tt {
     display: inline;
     max-width: initial;
     padding: 0;
@@ -166,9 +173,12 @@ a {
     word-wrap: normal;
     background-color: transparent;
     border: 0; }
-    .main-content pre code:before, .main-content pre code:after, .main-content pre tt:before, .main-content pre tt:after {
+    .main-content pre code:before, .main-content pre code:after,
+    .main-content pre tt:before,
+    .main-content pre tt:after {
       content: normal; }
-  .main-content ul, .main-content ol {
+  .main-content ul,
+  .main-content ol {
     margin-top: 0; }
   .main-content blockquote {
     padding: 0 1rem;
@@ -188,7 +198,8 @@ a {
     -webkit-overflow-scrolling: touch; }
     .main-content table th {
       font-weight: bold; }
-    .main-content table th, .main-content table td {
+    .main-content table th,
+    .main-content table td {
       padding: 0.5rem 1rem;
       border: 1px solid #e9ebec; }
   .main-content dl {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "immunity",
+  "name": "Cayman",
   "version": "1.0.0",
-  "homepage": "http://github.com/jasonlong/immunity-theme",
+  "homepage": "http://github.com/jasonlong/cayman-theme",
   "author": "Jason Long",
-  "scss": "./scss/immunity.scss",
+  "scss": "./scss/cayman.scss",
   "devDependencies": {
     "grunt-browser-sync": "~2.1.1",
-    "grunt": "~0.4.5",
-    "grunt-autoprefixer": "~2.2.0",
-    "grunt-sass": "~0.18.0",
-    "grunt-contrib-watch": "~0.6.1"
+    "grunt": "~1.0.1",
+    "grunt-autoprefixer": "~3.0.4",
+    "grunt-sass": "~1.1.0",
+    "grunt-contrib-watch": "~1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "grunt-browser-sync": "~2.1.1",
     "grunt": "~1.0.1",
-    "grunt-autoprefixer": "~3.0.4",
+    "grunt-postcss": "~0.8.0",
     "grunt-sass": "~1.1.0",
     "grunt-contrib-watch": "~1.0.0"
   }


### PR DESCRIPTION
Just bringing the Grunt packages up-to-date. Also, switching to `grunt-postcss` from the deprecated `grunt-autocompleter`.