### PR TITLE
Make variables default

### DIFF
--- a/scss/cayman.scss
+++ b/scss/cayman.scss
@@ -1,26 +1,26 @@
 // Breakpoints
-$large-breakpoint: 64em;
-$medium-breakpoint: 42em;
+$large-breakpoint: 64em !default;
+$medium-breakpoint: 42em !default;
 
 // Headers
-$header-heading-color: #fff;
-$header-bg-color: #159957;
-$header-bg-color-secondary: #155799;
+$header-heading-color: #fff !default;
+$header-bg-color: #159957 !default;
+$header-bg-color-secondary: #155799 !default;
 
 // Text
-$section-headings-color: #159957;
-$body-text-color: #606c71;
-$body-link-color: #1e6bb8;
-$blockquote-text-color: #819198;
+$section-headings-color: #159957 !default;
+$body-text-color: #606c71 !default;
+$body-link-color: #1e6bb8 !default;
+$blockquote-text-color: #819198 !default;
 
 // Code
-$code-bg-color: #f3f6fa;
-$code-text-color: #567482;
+$code-bg-color: #f3f6fa !default;
+$code-text-color: #567482 !default;
 
 // Borders
-$border-color: #dce6f0;
-$table-border-color: #e9ebec;
-$hr-border-color: #eff0f1;
+$border-color: #dce6f0 !default;
+$table-border-color: #e9ebec !default;
+$hr-border-color: #eff0f1 !default;
 
 @mixin large {
   @media screen and (min-width: #{$large-breakpoint}) {


### PR DESCRIPTION
In order to change any colors for the Cayman theme, you must currently edit `_cayman.scss`. Instead, this PR makes the variables default, allowing you to import the Cayman theme and set the colors without changing `_cayman.scss`:

``` scss
// My colors
$header-bg-color: #3498db;
$header-bg-color-secondary: #2c3e50;

@import "cayman.scss";

...
```