### PR TITLE
Remove code-text-color variable

### DIFF
--- a/css/cayman.css
+++ b/css/cayman.css
@@ -127,7 +127,6 @@ a {
     padding: 2px 4px;
     font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
     font-size: 0.9rem;
-    color: #567482;
     background-color: #f3f6fa;
     border-radius: 0.3rem; }
   .main-content pre {
@@ -135,7 +134,6 @@ a {
     margin-top: 0;
     margin-bottom: 1rem;
     font: 1rem Consolas, "Liberation Mono", Menlo, Courier, monospace;
-    color: #567482;
     word-wrap: normal;
     background-color: #f3f6fa;
     border: solid 1px #dce6f0;
@@ -144,7 +142,6 @@ a {
       padding: 0;
       margin: 0;
       font-size: 0.9rem;
-      color: #567482;
       word-break: normal;
       white-space: pre;
       background: transparent;

--- a/scss/cayman.scss
+++ b/scss/cayman.scss
@@ -15,7 +15,6 @@ $blockquote-text-color: #819198;
 
 // Code
 $code-bg-color: #f3f6fa;
-$code-text-color: #567482;
 
 // Borders
 $border-color: #dce6f0;
@@ -208,7 +207,6 @@ a {
     padding: 2px 4px;
     font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
     font-size: 0.9rem;
-    color: $code-text-color;
     background-color: $code-bg-color;
     border-radius: 0.3rem;
   }
@@ -218,7 +216,6 @@ a {
     margin-top: 0;
     margin-bottom: 1rem;
     font: 1rem Consolas, "Liberation Mono", Menlo, Courier, monospace;
-    color: $code-text-color;
     word-wrap: normal;
     background-color: $code-bg-color;
     border: solid 1px $border-color;
@@ -228,7 +225,6 @@ a {
       padding: 0;
       margin: 0;
       font-size: 0.9rem;
-      color: $code-text-color;
       word-break: normal;
       white-space: pre;
       background: transparent;


### PR DESCRIPTION
Fixes #26

The color difference is negligible, so let's keep using the default color. This prevents conflicts with links inside code blocks.